### PR TITLE
fixed getChildren issue for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       os: linux
       env:
         - PYTHON_VERSION="3.7"
-     - language: python
+    - language: python
       os: linux
       env:
         - PYTHON_VERSION="3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,14 @@ matrix:
       os: linux
       env:
         - PYTHON_VERSION="3.7"
+     - language: python
+      os: linux
+      env:
+        - PYTHON_VERSION="3.8"
+    - language: python
+      os: linux
+      env:
+        - PYTHON_VERSION="3.9"
 
 install:
   - sudo apt-get update

--- a/pytrackmate/_trackmate.py
+++ b/pytrackmate/_trackmate.py
@@ -37,7 +37,7 @@ def trackmate_peak_import(trackmate_xml_path, get_tracks=False):
                      'SNR': 'snr'}
 
     features = root.find('Model').find('FeatureDeclarations').find('SpotFeatures')
-    features = [c.get('feature') for c in features.getchildren()] + ['ID']
+    features = [c.get('feature') for c in list(features)] + ['ID']
 
     spots = root.find('Model').find('AllSpots')
     trajs = pd.DataFrame([])


### PR DESCRIPTION
GetChildren attribute has been deprecated in the new py 3.9 therefore list has to be to used instead.