### PR TITLE
column reindexing using .loc deprecated

### DIFF
--- a/pytrackmate/_trackmate.py
+++ b/pytrackmate/_trackmate.py
@@ -70,7 +70,7 @@ def trackmate_peak_import(trackmate_xml_path, get_tracks=False):
                              value=float(spot_filter.get('value')),
                              isabove=True if spot_filter.get('isabove') == 'true' else False)
 
-    trajs = trajs.loc[:, object_labels.keys()]
+    trajs = trajs.reindex(columns = object_labels.keys())
     trajs.columns = [object_labels[k] for k in object_labels.keys()]
     trajs['label'] = np.arange(trajs.shape[0])
 


### PR DESCRIPTION
This fix prevents the following error:

KeyError: "Passing list-likes to .loc or [] with any missing labels is no longer supported. The following labels were missing: Index(['MEAN_INTENSITY', 'ESTIMATED_DIAMETER', 'MEDIAN_INTENSITY',\n       'MIN_INTENSITY', 'MAX_INTENSITY', 'TOTAL_INTENSITY',\n       'STANDARD_DEVIATION', 'CONTRAST', 'SNR'],\n      dtype='object'). See https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"

See also: https://stackoverflow.com/questions/61291741/passing-list-likes-to-loc-or-with-any-missing-labels-is-no-longer-supported