### PR TITLE
Fixing np.float to float

### DIFF
--- a/pytrackmate/_trackmate.py
+++ b/pytrackmate/_trackmate.py
@@ -50,7 +50,7 @@ def trackmate_peak_import(trackmate_xml_path, get_tracks=False):
             objects.append(single_object)
 
     trajs = pd.DataFrame(objects, columns=features)
-    trajs = trajs.astype(np.float)
+    trajs = trajs.astype(float)
 
     # Apply initial filtering
     initial_filter = root.find("Settings").find("InitialSpotFilter")


### PR DESCRIPTION
Hi @hadim,

`pytrackmate` is not working for the latest version of `numpy`.

 I'm getting this error.

```python3
  /tmp/.tox/py39-linux-pyqt6/lib/python3.9/site-packages/pytrackmate/_trackmate.py:53: in trackmate_peak_import
      trajs = trajs.astype(np.float)
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  
  attr = 'float'
  
      def __getattr__(attr):
          # Warn for expired attributes, and return a dummy function
          # that always raises an exception.
          import warnings
          try:
              msg = __expired_functions__[attr]
          except KeyError:
              pass
          else:
              warnings.warn(msg, DeprecationWarning, stacklevel=2)
      
              def _expired(*args, **kwds):
                  raise RuntimeError(msg)
      
              return _expired
      
          # Emit warnings for deprecated attributes
          try:
              val, msg = __deprecated_attrs__[attr]
          except KeyError:
              pass
          else:
              warnings.warn(msg, DeprecationWarning, stacklevel=2)
              return val
      
          if attr in __future_scalars__:
              # And future warnings for those that will change, but also give
              # the AttributeError
              warnings.warn(
                  f"In the future `np.{attr}` will be defined as the "
                  "corresponding NumPy scalar.", FutureWarning, stacklevel=2)
      
          if attr in __former_attrs__:
  >           raise AttributeError(__former_attrs__[attr])
  E           AttributeError: module 'numpy' has no attribute 'float'.
  E           `np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  E           The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
  E               https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

```

If you want more context, you can see it [here](https://github.com/royerlab/ultrack/actions/runs/5981099424/job/16228407549?pr=45).

This PR fixes this issue, if you could bump the version and update `pypi` once you merge this it would be great.

Thanks for maintaining this package.